### PR TITLE
gan archiecture + generation changes

### DIFF
--- a/models/models/gan/gan_2D.py
+++ b/models/models/gan/gan_2D.py
@@ -264,6 +264,7 @@ class GAN(MusicModel):
         return ProgressMetadata(x_label='Epoch', y_label='loss', legends=['Discriminator loss', 'Generator loss'])
 
 
+'''
 if __name__ == '__main__':
 
     g = GAN()
@@ -274,3 +275,4 @@ if __name__ == '__main__':
             if fname.endswith('.mid'):
                 midi_paths.append(fname)
     g.train_on_files(midi_paths, 2000, lambda epoch: None, checkpoint_path='xd')
+'''

--- a/models/models/gan/gan_2D.py
+++ b/models/models/gan/gan_2D.py
@@ -7,6 +7,7 @@ from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.models import Sequential, load_model
 from tensorflow.keras.layers import Dense, Reshape, Flatten, Dropout, LeakyReLU, Conv1D, Conv1DTranspose, Activation
 from tensorflow.keras import activations
+from sklearn.utils import shuffle
 
 from midi.decode import get_array_of_notes
 from midi.encode import get_file_from_standard_features
@@ -16,7 +17,7 @@ DATA_PATH = 'data'
 
 AVG = 512  # length of generated array
 
-LATENT_DIM = 512  # dimension of latent space
+LATENT_DIM = 64  # dimension of latent space
 # higher LATENT_DIM -> samples produced by generator converge more to dataset
 
 REAL_MULTIPLIER = 1.0  # multiplier of real samples [0; 1];
@@ -27,7 +28,7 @@ SAVE_STEP = 100
 THRESHOLD = 0.7  # threshold of probability while generating a midi file
 # GAN generates probabilities that note is on during specific time unit
 
-N_BATCH = 10  # number of batches the dataset is divided into
+N_BATCH = 2  # number of batches the dataset is divided into
 
 GLOBAL_SEED = 2137
 
@@ -50,24 +51,31 @@ class GAN(MusicModel):
     def prepare_data(self, midi_file: Path) -> tuple[Any, Any]:
         data_lines = get_array_of_notes(midi_file, False, True)
         assert data_lines.shape[1] == 128, "Incorrect number of notes (expected: 128)"
-        data_processed = np.zeros((1, AVG, 128))
 
-        # trim or extend data to shape (AVG x 128)
-        if (data_lines.shape[0]) > AVG:
-            data_processed[0] = np.delete(
-                data_lines, slice(AVG, data_lines.shape[0]), 0)
-        else:
-            data_processed[0][0:data_lines.shape[0]] = data_lines
+        for i in range(data_lines.shape[0]//AVG - 1):
 
-        self.data = np.append(self.data, data_processed, axis=0)
-        self.data = np.array(self.data, dtype=np.float16)
+            # maximum number of samples
+            if (self.data.shape[0] > 1600):
+                break
+            data_processed = np.zeros((1, AVG, 128))
+            # divide data into chunks (AVG x 128)
+            if (data_lines.shape[0]) > AVG*(i+1):
+                data_processed[0] = data_lines[AVG*i: AVG*(i+1), ]
+
+            self.data = np.array(np.append(self.data, data_processed, axis=0), dtype=np.float16)
 
         # y: 1 - the image is real, 0 - the image is fake
-        return data_processed, 1
+        return data_lines, 1
 
     def postprocess_array(self, array: np.ndarray) -> np.ndarray:
         if array.shape[1] != 128:
             array = np.swapaxes(array, 0, 1)
+
+        if array.shape == (512, 128):
+            array = array[:, ~np.isnan(array).any(axis=0)]
+        else:
+            return np.zeros(1)
+
         out = (array - np.min(array)) / (np.max(array) - np.min(array))
         out[out < THRESHOLD] = 0
         out *= 255
@@ -84,6 +92,9 @@ class GAN(MusicModel):
         self.save_models(path, self.model, 0)
 
     def save_npy(self, prediction: np.ndarray, save_path: Path | None, save_name: str) -> None:
+
+        assert np.sum(prediction) > 0, "You want to save an empty file"
+
         if save_path is not None:
             os.makedirs(save_path, exist_ok=True)
             np.save('{}/{}'.format(save_path, save_name), prediction)
@@ -105,18 +116,16 @@ class GAN(MusicModel):
         start_width = AVG // 8
         filters = 128*AVG // 4
 
-        model.add(Conv1D(64, 3, padding='same', input_shape=(128, AVG)))
-        model.add(LeakyReLU(alpha=0.2))
-
-        model.add(Conv1D(32, 3, padding='same'))
+        model.add(Conv1D(16, 3, padding='same'))
         model.add(LeakyReLU(alpha=0.2))
 
         model.add(Flatten())
         model.add(Dropout(0.4))
 
-        model.add(Activation(activations.gelu))
-        opt = Adam(learning_rate=0.0005, beta_1=0.5)
-        model.compile(loss='mae', optimizer=opt, metrics=['Accuracy'])
+        model.add(Dense(1, activation='tanh'))
+
+        opt = Adam(learning_rate=0.001)
+        model.compile(loss='binary_crossentropy', optimizer=opt, metrics=['Accuracy', 'Precision', 'Recall', 'AUC'])
 
         return model
 
@@ -131,17 +140,18 @@ class GAN(MusicModel):
         model.add(LeakyReLU(alpha=0.2))
         model.add(Reshape((4, n_nodes//4)))
 
-        model.add(Conv1DTranspose(filters, 3, strides=2, padding='same'))
-        model.add(LeakyReLU(alpha=0.2))
-
-        model.add(Conv1DTranspose(filters, 3, strides=4, padding='same'))
+        model.add(Conv1DTranspose(filters//2, 3, strides=4, padding='same'))
         model.add(LeakyReLU(alpha=0.2))
 
         model.add(Conv1DTranspose(filters//2, 3, strides=4, padding='same'))
         model.add(LeakyReLU(alpha=0.2))
 
+        model.add(Conv1DTranspose(filters//4, 3, strides=4, padding='same'))
+        model.add(LeakyReLU(alpha=0.2))
+
         model.add(Dropout(0.2))
         model.add(Reshape((128, AVG)))
+        model.add(Activation(activations.tanh))
 
         return model
 
@@ -157,8 +167,8 @@ class GAN(MusicModel):
         model.layers[1]._name = 'discriminator'
 
         if not optimizer:
-            optimizer = Adam(lr=0.04, beta_1=0.5)
-        model.compile(loss=loss, optimizer=optimizer, metrics=['Accuracy'])
+            optimizer = Adam(lr=0.001)
+        model.compile(loss=loss, optimizer=optimizer, metrics=['Accuracy', 'Precision', 'Recall', 'AUC'])
         model.add(Flatten())
         print(model.summary())
 
@@ -175,8 +185,7 @@ class GAN(MusicModel):
         return np.swapaxes(np.asarray(x), 1, 2), y
 
     def generate_latent_points(self, latent_dim: int, n_samples: int, seed: int) -> np.ndarray:
-        rng = np.random.default_rng(seed)
-        x_input = rng.integers(2, size=latent_dim * n_samples)
+        x_input = np.random.randint(2, size=latent_dim * n_samples)
         x_input = x_input.reshape(n_samples, latent_dim)
 
         return x_input
@@ -217,29 +226,29 @@ class GAN(MusicModel):
             x_real, y_real = self.generate_real_samples(self.data, half_batch)
             x_fake, y_fake = self.generate_fake_samples(self.generator, LATENT_DIM, half_batch, GLOBAL_SEED)
 
-            d_loss1 = self.discriminator.train_on_batch(x_real, y_real)
-            d_loss2 = self.discriminator.train_on_batch(x_fake, y_fake)
+            x, y = np.vstack((x_real, x_fake)), np.vstack((y_real, y_fake))
+            x, y = shuffle(x, y)
+            d_loss = self.discriminator.train_on_batch(x, y)
 
             z_input = self.generate_latent_points(LATENT_DIM, N_BATCH, GLOBAL_SEED)
             y_real2 = np.ones((N_BATCH, 1))
             g_loss = self.model.train_on_batch(z_input, y_real2)
 
             x, y = self.generate_fake_samples(self.generator, LATENT_DIM, 25, GLOBAL_SEED)
+            progress_callback([(d_loss[0], step), (g_loss[0], step)])
 
-            progress_callback([((d_loss1[0] + d_loss2[0])/2, step), (g_loss[0], step)])
-
-            history['discriminator_real_loss'].append(d_loss1)
-            history['discriminator_fake_loss'].append(d_loss2)
+            history['discriminator_real_loss'].append(d_loss)
+            history['discriminator_fake_loss'].append(d_loss)
             history['generator_loss'].append(g_loss)
             epoch = step // batch_per_epoch + 1
 
             if step % batch_per_epoch == 0:
-                print('epoch: %d, discriminator_real_loss=%.3f, discriminator_fake_loss=%.3f, generator_loss=%.3f \n'
-                      % (epoch, d_loss1[0], d_loss2[0], g_loss[0]))
+                print('epoch: %d, discriminator_loss=%.3f,  generator_loss=%.3f \n'
+                      % (epoch, d_loss[0],  g_loss[0]))
 
             if step % SAVE_STEP == 0:
                 self.save_npy(self.postprocess_array(x_fake[0]), checkpoint_path, str(step))
-                self.save_models(checkpoint_path, self.model, step)
+                # self.save_models(checkpoint_path, self.model, step)
 
     def generate(self, path: Path, seed: int | list[int] | None = None) -> None:
         if (isinstance(seed, int)):
@@ -255,15 +264,13 @@ class GAN(MusicModel):
         return ProgressMetadata(x_label='Epoch', y_label='loss', legends=['Discriminator loss', 'Generator loss'])
 
 
-'''
 if __name__ == '__main__':
 
     g = GAN()
     midi_paths = []
-    for dirpath, dirs, files in os.walk(DATA_PATH): 
+    for dirpath, dirs, files in os.walk(DATA_PATH):
         for filename in files:
-            fname = os.path.join(dirpath,filename)
+            fname = os.path.join(dirpath, filename)
             if fname.endswith('.mid'):
                 midi_paths.append(fname)
-    g.train_on_files(midi_paths, 2000, lambda epoch : None, checkpoint_path='xd')
-'''
+    g.train_on_files(midi_paths, 2000, lambda epoch: None, checkpoint_path='xd')


### PR DESCRIPTION
main changes:

- data is now chunked into intervals of length 512, instead of taking first 512 values (more samples)
- training data is now mixed and shuffled
- models are downsized (from ~5M parameters to ~1M) without loss of quality
- changed loss to binary_crossentropy, minor architectural changes
- saving .npy file handles NaN values
- stopped using `numpy.random.Generator ` since it produced the same number each time it was initiated